### PR TITLE
Fix getter of CANCoder absolute angle

### DIFF
--- a/src/main/java/com/swervedrivespecialties/swervelib/ctre/CanCoderFactoryBuilder.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/ctre/CanCoderFactoryBuilder.java
@@ -50,7 +50,7 @@ public class CanCoderFactoryBuilder {
 
         @Override
         public double getAbsoluteAngle() {
-            double angle = Math.toRadians(encoder.getPosition());
+            double angle = Math.toRadians(encoder.getAbsolutePosition());
 
             ErrorCode code = encoder.getLastError();
 
@@ -59,7 +59,7 @@ public class CanCoderFactoryBuilder {
                 try {
                     Thread.sleep(10);
                 } catch (InterruptedException e) { }
-                angle = Math.toRadians(encoder.getPosition());
+                angle = Math.toRadians(encoder.getAbsolutePosition());
                 code = encoder.getLastError();
             }
 


### PR DESCRIPTION
I apologize if this is wrong (I am not very experienced with pull requests and such), but shouldn't this method be getting the encoder's absolute position based on the name?