### PR TITLE
Updated resetInteration to initialize to 500

### DIFF
--- a/src/main/java/com/swervedrivespecialties/swervelib/ctre/Falcon500SteerControllerFactoryBuilder.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/ctre/Falcon500SteerControllerFactoryBuilder.java
@@ -177,7 +177,7 @@ public final class Falcon500SteerControllerFactoryBuilder {
 
         private double referenceAngleRadians = 0.0;
 
-        private double resetIteration = 500;
+        private double resetIteration = ENCODER_RESET_ITERATIONS;
 
         private ControllerImplementation(WPI_TalonFX motor,
                 double motorEncoderPositionCoefficient,

--- a/src/main/java/com/swervedrivespecialties/swervelib/ctre/Falcon500SteerControllerFactoryBuilder.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/ctre/Falcon500SteerControllerFactoryBuilder.java
@@ -29,7 +29,8 @@ public final class Falcon500SteerControllerFactoryBuilder {
     private double nominalVoltage = Double.NaN;
     private double currentLimit = Double.NaN;
 
-    public Falcon500SteerControllerFactoryBuilder withPidConstants(double proportional, double integral, double derivative) {
+    public Falcon500SteerControllerFactoryBuilder withPidConstants(double proportional, double integral,
+            double derivative) {
         this.proportionalConstant = proportional;
         this.integralConstant = integral;
         this.derivativeConstant = derivative;
@@ -37,10 +38,12 @@ public final class Falcon500SteerControllerFactoryBuilder {
     }
 
     public boolean hasPidConstants() {
-        return Double.isFinite(proportionalConstant) && Double.isFinite(integralConstant) && Double.isFinite(derivativeConstant);
+        return Double.isFinite(proportionalConstant) && Double.isFinite(integralConstant)
+                && Double.isFinite(derivativeConstant);
     }
 
-    public Falcon500SteerControllerFactoryBuilder withMotionMagic(double velocityConstant, double accelerationConstant, double staticConstant) {
+    public Falcon500SteerControllerFactoryBuilder withMotionMagic(double velocityConstant, double accelerationConstant,
+            double staticConstant) {
         this.velocityConstant = velocityConstant;
         this.accelerationConstant = accelerationConstant;
         this.staticConstant = staticConstant;
@@ -48,7 +51,8 @@ public final class Falcon500SteerControllerFactoryBuilder {
     }
 
     public boolean hasMotionMagic() {
-        return Double.isFinite(velocityConstant) && Double.isFinite(accelerationConstant) && Double.isFinite(staticConstant);
+        return Double.isFinite(velocityConstant) && Double.isFinite(accelerationConstant)
+                && Double.isFinite(staticConstant);
     }
 
     public Falcon500SteerControllerFactoryBuilder withVoltageCompensation(double nominalVoltage) {
@@ -69,11 +73,13 @@ public final class Falcon500SteerControllerFactoryBuilder {
         return Double.isFinite(currentLimit);
     }
 
-    public <T> SteerControllerFactory<ControllerImplementation, SteerConfiguration<T>> build(AbsoluteEncoderFactory<T> absoluteEncoderFactory) {
+    public <T> SteerControllerFactory<ControllerImplementation, SteerConfiguration<T>> build(
+            AbsoluteEncoderFactory<T> absoluteEncoderFactory) {
         return new FactoryImplementation<>(absoluteEncoderFactory);
     }
 
-    private class FactoryImplementation<T> implements SteerControllerFactory<ControllerImplementation, SteerConfiguration<T>> {
+    private class FactoryImplementation<T>
+            implements SteerControllerFactory<ControllerImplementation, SteerConfiguration<T>> {
         private final AbsoluteEncoderFactory<T> encoderFactory;
 
         private FactoryImplementation(AbsoluteEncoderFactory<T> encoderFactory) {
@@ -83,14 +89,17 @@ public final class Falcon500SteerControllerFactoryBuilder {
         @Override
         public void addDashboardEntries(ShuffleboardContainer container, ControllerImplementation controller) {
             SteerControllerFactory.super.addDashboardEntries(container, controller);
-            container.addNumber("Absolute Encoder Angle", () -> Math.toDegrees(controller.absoluteEncoder.getAbsoluteAngle()));
+            container.addNumber("Absolute Encoder Angle",
+                    () -> Math.toDegrees(controller.absoluteEncoder.getAbsoluteAngle()));
         }
 
         @Override
-        public ControllerImplementation create(SteerConfiguration<T> steerConfiguration, String canbus, MechanicalConfiguration mechConfiguration) {
+        public ControllerImplementation create(SteerConfiguration<T> steerConfiguration, String canbus,
+                MechanicalConfiguration mechConfiguration) {
             AbsoluteEncoder absoluteEncoder = encoderFactory.create(steerConfiguration.getEncoderConfiguration());
 
-            final double sensorPositionCoefficient = 2.0 * Math.PI / TICKS_PER_ROTATION * mechConfiguration.getSteerReduction();
+            final double sensorPositionCoefficient = 2.0 * Math.PI / TICKS_PER_ROTATION
+                    * mechConfiguration.getSteerReduction();
             final double sensorVelocityCoefficient = sensorPositionCoefficient * 10.0;
 
             TalonFXConfiguration motorConfiguration = new TalonFXConfiguration();
@@ -101,11 +110,14 @@ public final class Falcon500SteerControllerFactoryBuilder {
             }
             if (hasMotionMagic()) {
                 if (hasVoltageCompensation()) {
-                    motorConfiguration.slot0.kF = (1023.0 * sensorVelocityCoefficient / nominalVoltage) * velocityConstant;
+                    motorConfiguration.slot0.kF = (1023.0 * sensorVelocityCoefficient / nominalVoltage)
+                            * velocityConstant;
                 }
-                // TODO: What should be done if no nominal voltage is configured? Use a default voltage?
+                // TODO: What should be done if no nominal voltage is configured? Use a default
+                // voltage?
 
-                // TODO: Make motion magic max voltages configurable or dynamically determine optimal values
+                // TODO: Make motion magic max voltages configurable or dynamically determine
+                // optimal values
                 motorConfiguration.motionCruiseVelocity = 2.0 / velocityConstant / sensorVelocityCoefficient;
                 motorConfiguration.motionAcceleration = (8.0 - 2.0) / accelerationConstant / sensorVelocityCoefficient;
             }
@@ -118,27 +130,32 @@ public final class Falcon500SteerControllerFactoryBuilder {
             }
 
             WPI_TalonFX motor = new WPI_TalonFX(steerConfiguration.getMotorPort(), canbus);
-            checkCtreError(motor.configAllSettings(motorConfiguration, CAN_TIMEOUT_MS), "Failed to configure Falcon 500 settings");
+            checkCtreError(motor.configAllSettings(motorConfiguration, CAN_TIMEOUT_MS),
+                    "Failed to configure Falcon 500 settings");
 
             if (hasVoltageCompensation()) {
                 motor.enableVoltageCompensation(true);
             }
-            checkCtreError(motor.configSelectedFeedbackSensor(TalonFXFeedbackDevice.IntegratedSensor, 0, CAN_TIMEOUT_MS), "Failed to set Falcon 500 feedback sensor");
+            checkCtreError(
+                    motor.configSelectedFeedbackSensor(TalonFXFeedbackDevice.IntegratedSensor, 0, CAN_TIMEOUT_MS),
+                    "Failed to set Falcon 500 feedback sensor");
             motor.setSensorPhase(true);
-            motor.setInverted(mechConfiguration.isSteerInverted() ? TalonFXInvertType.CounterClockwise : TalonFXInvertType.Clockwise);
+            motor.setInverted(mechConfiguration.isSteerInverted() ? TalonFXInvertType.CounterClockwise
+                    : TalonFXInvertType.Clockwise);
             motor.setNeutralMode(NeutralMode.Brake);
 
-            checkCtreError(motor.setSelectedSensorPosition(absoluteEncoder.getAbsoluteAngle() / sensorPositionCoefficient, 0, CAN_TIMEOUT_MS), "Failed to set Falcon 500 encoder position");
+            checkCtreError(
+                    motor.setSelectedSensorPosition(absoluteEncoder.getAbsoluteAngle() / sensorPositionCoefficient, 0,
+                            CAN_TIMEOUT_MS),
+                    "Failed to set Falcon 500 encoder position");
 
             // Reduce CAN status frame rates
             CtreUtils.checkCtreError(
                     motor.setStatusFramePeriod(
                             StatusFrameEnhanced.Status_1_General,
                             STATUS_FRAME_GENERAL_PERIOD_MS,
-                            CAN_TIMEOUT_MS
-                    ),
-                    "Failed to configure Falcon status frame period"
-            );
+                            CAN_TIMEOUT_MS),
+                    "Failed to configure Falcon status frame period");
 
             return new ControllerImplementation(motor,
                     sensorPositionCoefficient,
@@ -160,13 +177,13 @@ public final class Falcon500SteerControllerFactoryBuilder {
 
         private double referenceAngleRadians = 0.0;
 
-        private double resetIteration = 0;
+        private double resetIteration = 500;
 
         private ControllerImplementation(WPI_TalonFX motor,
-                                         double motorEncoderPositionCoefficient,
-                                         double motorEncoderVelocityCoefficient,
-                                         TalonFXControlMode motorControlMode,
-                                         AbsoluteEncoder absoluteEncoder) {
+                double motorEncoderPositionCoefficient,
+                double motorEncoderVelocityCoefficient,
+                TalonFXControlMode motorControlMode,
+                AbsoluteEncoder absoluteEncoder) {
             this.motor = motor;
             this.motorEncoderPositionCoefficient = motorEncoderPositionCoefficient;
             this.motorEncoderVelocityCoefficient = motorEncoderVelocityCoefficient;
@@ -194,9 +211,12 @@ public final class Falcon500SteerControllerFactoryBuilder {
             double currentAngleRadians = motor.getSelectedSensorPosition() * motorEncoderPositionCoefficient;
 
             // Reset the NEO's encoder periodically when the module is not rotating.
-            // Sometimes (~5% of the time) when we initialize, the absolute encoder isn't fully set up, and we don't
-            // end up getting a good reading. If we reset periodically this won't matter anymore.
-            if (motor.getSelectedSensorVelocity() * motorEncoderVelocityCoefficient < ENCODER_RESET_MAX_ANGULAR_VELOCITY) {
+            // Sometimes (~5% of the time) when we initialize, the absolute encoder isn't
+            // fully set up, and we don't
+            // end up getting a good reading. If we reset periodically this won't matter
+            // anymore.
+            if (motor.getSelectedSensorVelocity()
+                    * motorEncoderVelocityCoefficient < ENCODER_RESET_MAX_ANGULAR_VELOCITY) {
                 if (++resetIteration >= ENCODER_RESET_ITERATIONS) {
                     resetIteration = 0;
                     double absoluteAngle = absoluteEncoder.getAbsoluteAngle();
@@ -212,7 +232,8 @@ public final class Falcon500SteerControllerFactoryBuilder {
                 currentAngleRadiansMod += 2.0 * Math.PI;
             }
 
-            // The reference angle has the range [0, 2pi) but the Falcon's encoder can go above that
+            // The reference angle has the range [0, 2pi) but the Falcon's encoder can go
+            // above that
             double adjustedReferenceAngleRadians = referenceAngleRadians + currentAngleRadians - currentAngleRadiansMod;
             if (referenceAngleRadians - currentAngleRadiansMod > Math.PI) {
                 adjustedReferenceAngleRadians -= 2.0 * Math.PI;
@@ -221,7 +242,6 @@ public final class Falcon500SteerControllerFactoryBuilder {
             }
 
             motor.set(motorControlMode, adjustedReferenceAngleRadians / motorEncoderPositionCoefficient);
-
 
             this.referenceAngleRadians = referenceAngleRadians;
         }


### PR DESCRIPTION
Causes the angle reset logic to trigger immediately the first time rather than waiting for 5-10s.  This mitigates some CAN/startup synchronization issues.

https://www.chiefdelphi.com/t/democat-sds-swervelib-with-cancoders/425355/25